### PR TITLE
[이석찬] 페이지네이션, 드롭다운, 멘토링 피드백 반영

### DIFF
--- a/open-mind/src/App.js
+++ b/open-mind/src/App.js
@@ -3,6 +3,7 @@ import Homepage from "./pages/Homepage/Homepage";
 import ButtonTest from "./components/commons/Buttons/ButtonTest";
 import IndividualFeed from "./pages/IndividualFeed/IndividualFeed";
 import QuestionListPage from "./pages/QuestionListPage/QuestionListPage";
+import Dropdowntest from "./components/commons/Dropdown/Dropdowntest";
 
 function App() {
   return (
@@ -16,6 +17,7 @@ function App() {
         </Route>
         {/* test용 페이지라서 따로 빼뒀습니다 */}
         <Route path="/buttontest" element={<ButtonTest />} />
+        <Route path="/dropdowntest" element={<Dropdowntest />} />
       </Routes>
     </BrowserRouter>
   );

--- a/open-mind/src/components/Commons/Dropdown/Dropdown.jsx
+++ b/open-mind/src/components/Commons/Dropdown/Dropdown.jsx
@@ -1,13 +1,19 @@
 import React, { useState, useRef, useEffect } from "react";
 import styles from "./dropdown.module.css";
 
-// values = 드롭다운 메뉴, 배열 형태로 입력
-// defaultValue = 기본 메뉴
-// onChange = 핸들러
-// iconDefault = 기본 메뉴 이미지
-// iconHover = 호버 상태일 때 이미지
-// iconActive = 드롭다운을 눌렀을 때 이미지
-// iconPosition = 텍스트 기준 앞(front), 뒤(back)
+/**
+ *
+ * @param {*} values = 드롭다운 메뉴, 배열 형태로 입력 (각 항목에 value와 icon 포함)
+ * @param {*} defaultValue = 기본 메뉴
+ * @param {*} onChange = 핸들러
+ * @param {*} iconDefault = 기본 메뉴 이미지
+ * @param {*} iconHover = 호버 상태일 때 이미지
+ * @param {*} iconActive = 드롭다운을 눌렀을 때 이미지
+ * @param {*} isImageButton = 버튼이 이미지인지 여부
+ * @param {*} imageButtonSrc = 이미지 버튼용 src
+ * @param {*} imageButtonAlt = 이미지 버튼용 alt 텍스트
+ * @returns
+ */
 
 function Dropdown({
   values,
@@ -16,12 +22,13 @@ function Dropdown({
   iconDefault,
   iconHover,
   iconActive,
-  iconPosition,
+  isImageButton = false,
+  imageButtonSrc,
+  imageButtonAlt = "드롭다운 버튼 이미지",
 }) {
   const [selectedValue, setSelectedValue] = useState(defaultValue);
   const [isOpen, setIsOpen] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
-  const [isActive, setIsActive] = useState(false);
 
   const dropdownRef = useRef(null);
 
@@ -46,7 +53,6 @@ function Dropdown({
 
   function toggleDropdown() {
     setIsOpen(!isOpen);
-    setIsActive(!isActive);
   }
 
   function handleMouseEnter() {
@@ -57,11 +63,7 @@ function Dropdown({
     setIsHovered(false);
   }
 
-  function handleBlur() {
-    setIsActive(!isActive);
-  }
-
-  const iconToShow = isActive
+  const iconToShow = isOpen
     ? iconActive // 드롭다운 열렸을 때는 iconActive
     : isHovered
       ? iconHover // 호버 상태에서는 iconHover 아이콘
@@ -69,38 +71,57 @@ function Dropdown({
 
   return (
     <div ref={dropdownRef} className={styles.dropdown}>
-      <button
-        className={`${styles.dropdown_button} ${isActive ? styles.dropdown_button_active : ""}`}
-        onClick={toggleDropdown}
-        onBlur={handleBlur}
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handleMouseLeave}
-      >
-        {iconPosition === "front" && iconToShow && (
+      {/* 버튼이 이미지인지 텍스트인지에 따라 다르게 렌더링 */}
+      {!isImageButton ? (
+        <button
+          className={`${styles.dropdown_button} ${
+            isOpen ? styles.dropdown_button_open : ""
+          }`}
+          onClick={toggleDropdown}
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
+        >
+          {selectedValue}
           <img
             className={styles.dropdown_icon}
             src={iconToShow}
             alt="드롭다운 아이콘"
           />
-        )}
-        {selectedValue}
-        {iconPosition === "back" && iconToShow && (
+        </button>
+      ) : (
+        <button
+          className={`${styles.dropdown_image_button} ${
+            isOpen ? styles.dropdown_button_open : ""
+          }`}
+          onClick={toggleDropdown}
+        >
           <img
-            className={styles.dropdown_icon}
-            src={iconToShow}
-            alt="드롭다운 아이콘"
+            src={imageButtonSrc}
+            alt={imageButtonAlt}
+            className={styles.image_button_icon}
           />
-        )}
-      </button>
+        </button>
+      )}
       <ul
-        className={`${styles.dropdown_menu} ${isOpen ? styles.dropdown_menu_show : ""}`}
+        className={`${styles.dropdown_menu} ${
+          isOpen ? styles.dropdown_menu_show : ""
+        }`}
       >
-        {values.map((value) => (
+        {values.map(({ value, icon }) => (
           <li
             key={value}
-            className={styles.dropdown_menu_item}
+            className={`${styles.dropdown_menu_item} ${
+              isImageButton ? styles.dropdown_menu_item_image : ""
+            }`}
             onClick={() => handleSelect(value)}
           >
+            {icon && (
+              <img
+                className={styles.dropdown_item_icon}
+                src={icon}
+                alt={`${value} 아이콘`}
+              />
+            )}
             {value}
           </li>
         ))}

--- a/open-mind/src/components/Commons/Dropdown/Dropdowntest.jsx
+++ b/open-mind/src/components/Commons/Dropdown/Dropdowntest.jsx
@@ -1,0 +1,28 @@
+import React from "react";
+import Dropdown from "./Dropdown";
+import Edit from "../../../assets/icon/edit.svg";
+import Close from "../../../assets/icon/close.svg";
+import More from "../../../assets/icon/more.svg";
+
+function Dropdowntest() {
+  const values = [{ value: "최신순" }, { value: "이름순" }];
+  const values1 = [
+    { value: "수정하기", icon: Edit },
+    { value: "삭제하기", icon: Close },
+  ];
+  return (
+    <>
+      <h1>버튼 = 텍스트 </h1>
+      <Dropdown values={values} defaultValue="최신순" />
+      <h1>버튼 = 이미지, 드롭다운 메뉴에 아이콘 </h1>
+      <Dropdown
+        values={values1}
+        isImageButton="true"
+        imageButtonSrc={More}
+        imageButtonAlt="드롭다운 버튼 이미지"
+      />
+    </>
+  );
+}
+
+export default Dropdowntest;

--- a/open-mind/src/components/Commons/Dropdown/dropdown.module.css
+++ b/open-mind/src/components/Commons/Dropdown/dropdown.module.css
@@ -21,7 +21,7 @@
   color: var(--gray60-color);
 }
 
-.dropdown_button_active {
+.dropdown_button_open {
   border: 1px solid var(--gray60-color);
   color: var(--gray60-color);
 }
@@ -44,6 +44,7 @@
   z-index: 1;
   list-style-type: none;
   padding: 0;
+  margin-top: 4px;
 }
 
 .dropdown_menu_item {
@@ -61,4 +62,18 @@
 
 .dropdown_menu_show {
   display: block;
+}
+
+/*드롭다운 버튼이 이미지인 경우*/
+
+.dropdown_image_button {
+  width: 26px;
+  height: 26px;
+  border: none;
+  background-color: transparent;
+}
+
+.dropdown_menu_item_image {
+  width: 103px;
+  height: 34px;
 }

--- a/open-mind/src/components/Commons/InputField/InputField.jsx
+++ b/open-mind/src/components/Commons/InputField/InputField.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import styles from "./inputField.module.css";
 import Person from "../../../assets/icon/person-gray.svg";
 
-function InputField({ value, onChange }) {
+function InputField({ value, onChange, placeholder }) {
   return (
     <div className={styles.input_container}>
       <img src={Person} alt="인풋 아이콘" className={styles.input_icon} />
@@ -10,7 +10,7 @@ function InputField({ value, onChange }) {
         type="text"
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        placeholder="이름을 입력하세요"
+        placeholder={placeholder}
         className={styles.input_field}
       />
     </div>

--- a/open-mind/src/components/Commons/Pagination/Pagination.jsx
+++ b/open-mind/src/components/Commons/Pagination/Pagination.jsx
@@ -1,0 +1,49 @@
+import React from "react";
+import styles from "./pagination.module.css";
+
+function Pagination({ currentPage, totalPages, onPageChange, groupSize = 5 }) {
+  // 현재 페이지 그룹 계산
+  const currentGroup = Math.ceil(currentPage / groupSize);
+  const groupStart = (currentGroup - 1) * groupSize + 1; // 그룹 시작 페이지
+  const groupEnd = Math.min(groupStart + groupSize - 1, totalPages); // 그룹 마지막 페이지
+
+  return (
+    <div className={styles.pagination}>
+      {/* 이전 페이지 버튼 */}
+      <button
+        onClick={() => onPageChange(currentPage - 1)}
+        disabled={currentPage === 1}
+        className={styles.pagination_prev_btn}
+      >
+        {"<"}
+      </button>
+
+      {/* 페이지 번호 버튼 생성 */}
+      {Array.from(
+        { length: groupEnd - groupStart + 1 },
+        (_, index) => groupStart + index
+      ).map((page) => (
+        <button
+          key={page}
+          onClick={() => onPageChange(page)}
+          className={`${styles.pageNum} ${
+            currentPage === page ? styles.activePage : ""
+          }`}
+        >
+          {page}
+        </button>
+      ))}
+
+      {/* 다음 페이지 버튼 */}
+      <button
+        onClick={() => onPageChange(currentPage + 1)}
+        disabled={currentPage === totalPages} // 마지막 페이지일 경우 비활성화
+        className={styles.pagination_next_btn}
+      >
+        {">"}
+      </button>
+    </div>
+  );
+}
+
+export default Pagination;

--- a/open-mind/src/components/Commons/Pagination/pagination.module.css
+++ b/open-mind/src/components/Commons/Pagination/pagination.module.css
@@ -1,0 +1,28 @@
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.pagination,
+.pagination_prev_btn,
+.pagination_next_btn,
+.activePage,
+.pageNum {
+  cursor: pointer;
+  background-color: transparent;
+  border: none;
+  font-size: 20px;
+  color: var(--gray40-color);
+}
+
+.pagination,
+.pageNum:hover,
+.pagination_prev_btn:hover,
+.pagination_next_btn:hover {
+  color: var(--gray60-color);
+}
+
+.pagination .activePage {
+  color: var(--brown40-color);
+}

--- a/open-mind/src/components/Commons/UserCard/UserCard.jsx
+++ b/open-mind/src/components/Commons/UserCard/UserCard.jsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { getSubjectsList } from "../../../api/subjectApi/subjectApi.js";
 import styles from "./userCard.module.css";
 import Messages from "../../../assets/icon/messages-gray.svg";
+import Pagination from "../Pagination/Pagination.jsx";
 
 function UserCard({ sortType = "최신순" }) {
   const [subjects, setSubjects] = useState([]);
@@ -36,15 +37,6 @@ function UserCard({ sortType = "최신순" }) {
 
     fetchSubjects();
   }, [currentPage, sortType]);
-
-  // 페이지네이션 버튼 클릭 시
-  const handlePrevPage = () => {
-    if (currentPage > 1) setCurrentPage(currentPage - 1);
-  };
-
-  const handleNextPage = () => {
-    if (currentPage < totalPages) setCurrentPage(currentPage + 1);
-  };
 
   if (loading) {
     return <p className={styles.loading}>Loading...</p>;
@@ -85,37 +77,13 @@ function UserCard({ sortType = "최신순" }) {
         ))}
       </div>
 
-      {/* 페이지네이션 버튼 */}
-      <div className={styles.pagination}>
-        <button
-          onClick={handlePrevPage}
-          disabled={currentPage === 1}
-          className={styles.pagination_prev_btn}
-        >
-          {"<"}
-        </button>
-
-        {/* 페이지 번호 버튼 동적으로 생성 */}
-        {Array.from({ length: totalPages }, (_, index) => (
-          <button
-            key={index + 1}
-            onClick={() => setCurrentPage(index + 1)}
-            className={`${styles.pageNum} ${
-              currentPage === index + 1 ? styles.activePage : ""
-            }`}
-          >
-            {index + 1}
-          </button>
-        ))}
-
-        <button
-          onClick={handleNextPage}
-          disabled={currentPage === totalPages}
-          className={styles.pagination_next_btn}
-        >
-          {">"}
-        </button>
-      </div>
+      {/* 페이지네이션 컴포넌트 사용 */}
+      <Pagination
+        currentPage={currentPage}
+        totalPages={totalPages}
+        onPageChange={(page) => setCurrentPage(page)}
+        groupSize={5}
+      />
     </div>
   );
 }

--- a/open-mind/src/components/Commons/UserCard/userCard.module.css
+++ b/open-mind/src/components/Commons/UserCard/userCard.module.css
@@ -63,35 +63,6 @@ p {
   fill: var(--gray40-color);
 }
 
-.pagination {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.pagination,
-.pagination_prev_btn,
-.pagination_next_btn,
-.activePage,
-.pageNum {
-  cursor: pointer;
-  background-color: transparent;
-  border: none;
-  font-size: 20px;
-  color: var(--gray40-color);
-}
-
-.pagination,
-.pageNum:hover,
-.pagination_prev_btn:hover,
-.pagination_next_btn:hover {
-  color: var(--gray60-color);
-}
-
-.pagination .activePage {
-  color: var(--brown40-color);
-}
-
 .loading {
   text-align: center;
   font-size: 30px;

--- a/open-mind/src/pages/Homepage/Homepage.jsx
+++ b/open-mind/src/pages/Homepage/Homepage.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import styles from "./homepage.module.css"
+import styles from "./homepage.module.css";
 import InputField from "../../components/commons/InputField/InputField";
 import DefaultButton from "../../components/commons/Buttons/DefaultButton";
 import { Link, useNavigate } from "react-router-dom";
@@ -18,7 +18,7 @@ function Homepage() {
 
   const handleClickChange = () => {
     handleCreateFeed(name, navigate);
-  }
+  };
 
   return (
     <div className={styles.main}>
@@ -28,8 +28,16 @@ function Homepage() {
         </Link>
         <h1 className={styles.main__form_logo}>OPEN MIND 로고</h1>
         <div className={styles.main__form_group}>
-          <InputField value={name} onChange={handleInputChange} />
-          <DefaultButton onClick={handleClickChange} innerText={take_question_button} hasArrow={false} />
+          <InputField
+            value={name}
+            onChange={handleInputChange}
+            placeholder={"이름을 입력하세요"}
+          />
+          <DefaultButton
+            onClick={handleClickChange}
+            innerText={take_question_button}
+            hasArrow={false}
+          />
         </div>
       </div>
     </div>

--- a/open-mind/src/pages/QuestionListPage/QuestionListPage.jsx
+++ b/open-mind/src/pages/QuestionListPage/QuestionListPage.jsx
@@ -12,6 +12,7 @@ import DefaultButton from "../../components/commons/Buttons/DefaultButton";
 function QuestionListPage() {
   const [sortType, setSortType] = useState("최신순");
   const navigate = useNavigate();
+  const values = [{ value: "최신순" }, { value: "이름순" }];
 
   function handleDropdownChange(selectedValue) {
     setSortType(selectedValue);
@@ -48,13 +49,12 @@ function QuestionListPage() {
               누구에게 질문할까요?
             </h1>
             <Dropdown
-              values={["이름순", "최신순"]}
+              values={values}
               defaultValue="최신순"
               onChange={handleDropdownChange}
               iconDefault={ArrowDownGrayIcon}
               iconHover={ArrowDownDarkIcon}
               iconActive={ArrowUpDarkIcon}
-              iconPosition="back"
             />
           </div>
           <UserCard sortType={sortType} />


### PR DESCRIPTION
**작업 내용**

- 페이지네이션 기능 구현 완료 및 공용 컴포넌트로 분리
< 1 2 3 4 5 > 이후 다음버튼(">") 클릭 시 < 6 7 8 9 10 > 페이지 그룹 이동
![image](https://github.com/user-attachments/assets/1f218850-f327-4ef6-a140-24dd9f3c1559)

- 드롭다운 버튼이 이미지인 경우 기능 추가
드롭다운 메뉴에 아이콘도 추가할 수 있도록 values 프롭을 수정했으나,
드롭다운 메뉴 호버일 경우의 아이콘 등등 추가 기능 구현 필요
![image](https://github.com/user-attachments/assets/708a442a-3c2d-48bd-aa60-a638fb8ae2e4)


드롭다운 컴포넌트 사용 방법 공유를 위해 드롭다운 테스트 페이지 만들어놨습니다.
