### PR TITLE
[이은주] 메인페이지 디자인 수정 | 공통 버튼 컴포넌트 디자인 수정 | InputTextArea 추가

### DIFF
--- a/open-mind/src/components/Commons/Buttons/button.module.css
+++ b/open-mind/src/components/Commons/Buttons/button.module.css
@@ -106,7 +106,8 @@ body {
   font-family: Pretendard;
   width: 10.0625rem;
   height: 2.875rem;
-  border: 1px solid var(--brown40-color);
+  outline: 1px solid var(--brown40-color);
+  border: none;
   border-radius: 0.5rem;
   padding: 0.75rem 1.5rem;
   font-size: 1rem;
@@ -119,14 +120,14 @@ body {
 }
 
 .go_question_button:hover {
-  border: 2px solid var(--brown40-color);
+  outline: 2px solid var(--brown40-color);
 }
 
 .go_question_button:active {
   background-color: var(--brown20-color);
 }
 
-.go_question_button > img {
+.go_question_button>img {
   position: absolute;
 }
 

--- a/open-mind/src/components/Commons/InputTextArea/InputTextArea.jsx
+++ b/open-mind/src/components/Commons/InputTextArea/InputTextArea.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+import styles from "./InputTextArea.module.css";
+
+function InputTextArea({ value, onChange, placeholder }) {
+    return (
+        <textarea
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            placeholder={placeholder}
+            className={styles.textarea}
+        ></textarea>
+    );
+}
+
+export default InputTextArea;

--- a/open-mind/src/components/Commons/InputTextArea/InputTextArea.module.css
+++ b/open-mind/src/components/Commons/InputTextArea/InputTextArea.module.css
@@ -1,0 +1,17 @@
+.textarea {
+    outline: none;
+    border: none;
+    background-color: #F9F9F9;
+    border-radius: 0.5rem;
+    width: 100%;
+    height: 11.25rem;
+    padding: 1rem;
+    font-family: Pretendard;
+    font-size: 1rem;
+    font-weight: 400;
+    resize: none;
+}
+
+.textarea:focus {
+    outline: 1px solid var(--brown40-color);
+}

--- a/open-mind/src/components/Commons/Link/link.module.css
+++ b/open-mind/src/components/Commons/Link/link.module.css
@@ -25,7 +25,7 @@ body {
 }
 
 .link_item:hover {
-  border: 1px solid var(--gray60-color);
+  outline: 1px solid var(--gray60-color);
 }
 
 .link_item:active {
@@ -43,7 +43,7 @@ body {
 }
 
 .kakaotalk_item:hover {
-  border: 1px solid var(--gray60-color);
+  outline: 1px solid var(--gray60-color);
 }
 
 .kakaotalk_item:active {
@@ -61,7 +61,7 @@ body {
 }
 
 .facebook_item:hover {
-  border: 1px solid var(--gray60-color);
+  outline: 1px solid var(--gray60-color);
 }
 
 .facebook_item:active {

--- a/open-mind/src/components/Commons/Modal/Modal.jsx
+++ b/open-mind/src/components/Commons/Modal/Modal.jsx
@@ -3,17 +3,18 @@ import { getSubjects } from "../../../api/subjectApi/subjectApi";
 import questionIcon from "../../../assets/icon/messages.svg";
 import closeIcon from "../../../assets/icon/close.svg";
 import "./Modal.css";
+import InputTextArea from "../InputTextArea/InputTextArea";
 
 export default function Modal({ subjectId, setIsModal }) {
   const [subject, setSubject] = useState({});
   const [question, setQuestion] = useState("");
 
-  const handleInputChange = (e) => {
+  const handleInputChange = (value) => {
     // 질문 작성
-    setQuestion(e.target.value);
+    setQuestion(value);
   };
 
-  const handlePost = () => {}; // 질문 제출
+  const handlePost = () => { }; // 질문 제출
 
   useEffect(() => {
     const fetchSubjectData = async () => {
@@ -63,12 +64,12 @@ export default function Modal({ subjectId, setIsModal }) {
             />
             <h4>{subject.name}</h4>
           </div>
-          <input
+          <InputTextArea
             className="modal_question"
             placeholder="질문을 입력해주세요"
             value={question}
             onChange={handleInputChange}
-          ></input>
+          ></InputTextArea>
           <button
             className="post_button"
             type="button"

--- a/open-mind/src/pages/Homepage/homepage.module.css
+++ b/open-mind/src/pages/Homepage/homepage.module.css
@@ -75,4 +75,8 @@
   .main__form_group {
     order: 2;
   }
+
+  .main__form_group>button {
+    width: 100%;
+  }
 }


### PR DESCRIPTION
- 모바일일 때 디자인 수정했어요. (좌(수정전) / 우(수정후))
![12,19-1](https://github.com/user-attachments/assets/69628e89-1c40-42c0-bc44-bbd5fe7769cf)

- InputTextArea 컴포넌트 만들었습니다. value/ onChange / placeholder을 프롭으로 받아요.
- Modal.jsx에 기존 input대신 InputTextArea 컴포넌트로 바꿔두었어요. 모달창 페이지에서 확인 가능해요.
![12,19-2](https://github.com/user-attachments/assets/122f6698-555c-475c-8174-6ed64cf812bf)

- 공통으로 사용되는 질문하러가기, 답변하러가기 버튼 컴포넌트 hover했을 때 흔들림 없게끔 수정했어요.
![12,19-3](https://github.com/user-attachments/assets/c19aa68d-813f-4969-9187-862204bd63ce)

- SNS아이콘 hover했을 때 흔들림 없게끔 수정했어요.
![12,19-4](https://github.com/user-attachments/assets/7fed6729-d8f9-4132-98f2-25a133297edf)
