### PR TITLE
[이은주] 리스트 페이지 반응형 스타일 수정

### DIFF
--- a/open-mind/src/components/Commons/UserCard/userCard.module.css
+++ b/open-mind/src/components/Commons/UserCard/userCard.module.css
@@ -1,10 +1,11 @@
 .user_card_grid {
   display: grid;
-  width: 940px;
   grid-template-columns: repeat(4, 1fr);
   grid-template-rows: repeat(2, auto);
   gap: 20px;
+  width: 940px;
   margin: 0 auto 40px;
+  padding: 0 30px;
 }
 
 .subject_link {
@@ -13,7 +14,8 @@
 }
 
 .user_card {
-  width: 220px;
+  min-width: 186px;
+  max-width: 220px;
   height: 187px;
   border: 1px solid var(--gray40-color);
   border-radius: 16px;
@@ -76,12 +78,22 @@ p {
 }
 
 /* 태블릿 전용 스타일 */
-@media screen and (min-width: 768px) and (max-width: 1199px) {
-  .grid_container {
-    place-items: center;
+@media screen and (max-width: 875px) {
+  .user_card_grid {
+    grid-template-columns: repeat(3, 1fr);
+    height: 395px;
+    overflow: hidden;
+    max-width: 700px;
+    margin: 0 auto 40px;
+    padding: 0;
   }
 }
 
 /* 모바일 전용 스타일 */
-@media screen and (min-width: 375px) and (max-width: 767px) {
+@media screen and (max-width: 768px) {
+  .user_card_grid {
+    grid-template-columns: repeat(2, 1fr);
+    max-width: 460px;
+    height: 605px;
+  }
 }

--- a/open-mind/src/pages/QuestionListPage/questionListPage.module.css
+++ b/open-mind/src/pages/QuestionListPage/questionListPage.module.css
@@ -1,7 +1,7 @@
 .container {
   display: flex;
+  max-width: 1040px;
   flex-direction: column;
-  max-width: 1200px;
   margin: 40px auto;
 }
 
@@ -9,20 +9,19 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  max-width: 940px;
-  margin: 0 130px;
+  margin: 0px 50px 40px;
 }
 
 .header_logo {
   width: 146px;
   height: 57px;
-  flex-shrink: 0;
 }
 
 .body_top_banner {
   display: flex;
   flex-direction: column;
   align-items: center;
+  gap: 12px;
   margin: 40px;
 }
 
@@ -34,30 +33,29 @@
 }
 
 /* 태블릿 전용 스타일 */
-@media screen and (min-width: 768px) and (max-width: 1199px) {
-  .header {
-    margin: 0 auto;
-    width: 100%;
-    max-width: 850px;
-    padding: 0 50px;
+@media screen and (min-width: 769px) and (max-width: 1199px) {
+  .container {
+    margin-top: 40px;
   }
 }
 
+
 /* 모바일 전용 스타일 */
-@media screen and (min-width: 375px) and (max-width: 767px) {
+@media screen and (max-width: 768px) {
   .header {
+    margin: 0 auto;
     flex-direction: column;
-    margin: 0;
+    gap: 20px;
   }
 
   .body_top_banner {
     flex-direction: row;
-    justify-content: space-between;
-    margin: 52px 24px 16px;
+    margin: 40px 24px;
+    justify-content: center;
   }
 
   .body_top_banner_text {
-    font-size: 24px;
-    margin: 0;
+    font-size: 2.5rem;
+    margin-bottom: 0;
   }
 }


### PR DESCRIPTION
![bandicam-2024-12-23-13-25-09-867](https://github.com/user-attachments/assets/b0b293a0-4544-40c3-b7bf-7c15cf7fd5dc)

- PC에서 너비가 1200px 보다 커질 경우 내부 내용의 위치는 고정하고 좌우 여백만 커집니다.
- PC에서 카드 컴포넌트의 너비는 220px입니다.
- 상단 네비게이션 영역의 좌우 여백은 50px을 유지해주세요.
- 카드 리스트 영역의 좌우 최소 여백은 32px 입니다.
- 카드 컴포넌트의 최소 너비는 186px 입니다.
- 카드 리스트 영역이 줄어드는 것에 따라 카드 크기가 작아지다가 186px보다 작아질 때 하나의 행에 4개->3개씩 유지해주세요
- “누구에게 질문할까요?”는 좌측 여백 24px , 정렬 드롭다운은 우측 여백 24px을 유지하며 둘 사이의 간격이 멀어집니다.
- 카드 리스트 영역의 좌우 최소 여백은 24px 입니다.

위 요구 조건에서 끌어낸 최선입니다@_@